### PR TITLE
Docs fixes

### DIFF
--- a/holisticai/bias/mitigation/inprocessing/exponentiated_gradient/transformer.py
+++ b/holisticai/bias/mitigation/inprocessing/exponentiated_gradient/transformer.py
@@ -44,19 +44,16 @@ class ExponentiatedGradientReduction(BaseEstimator, ClassifierMixin, BMImp):
         max_val: float = None,
         upper_bound: float = 0.01,
         verbose: Optional[int] = 0,
+        estimator = None
     ):
 
         """
+        
         Parameters
         ----------
-
-        estimator: An estimator implementing methods
-            ``fit(X, y, sample_weight)`` and ``predict(X)``, where ``X`` is
-            the matrix of features, ``y`` is the vector of labels, and
-            ``sample_weight`` is a vector of weights; labels ``y`` and
-            predictions returned by ``predict(X)`` are either 0 or 1 -- e.g.
-            scikit-learn classifiers.
-
+        estimator : sklearn-like
+            The model you want to mitigate bias for.
+        
         constraints (str or BaseMoment): If string, keyword
             denoting the :class:`BaseMoment` object
             defining the disparity constraints:
@@ -107,8 +104,14 @@ class ExponentiatedGradientReduction(BaseEstimator, ClassifierMixin, BMImp):
         self.max_val = max_val
         self.upper_bound = upper_bound
         self.verbose = verbose
+        self.estimator = estimator
 
     def transform_estimator(self, estimator):
+        
+        """
+        This method is deprecated but retained for backwards-compatibility. You should pass the estimator object directly in the constructor. 
+        """
+
         self.estimator = estimator
         return self
 

--- a/holisticai/bias/mitigation/postprocessing/eq_odds_postprocessing.py
+++ b/holisticai/bias/mitigation/postprocessing/eq_odds_postprocessing.py
@@ -250,7 +250,7 @@ class EqualizedOdds(BMPost):
 
         Returns
         -------
-        dictionnary with new predictions
+        A dictionary with two keys, y_pred and y_score, which refers to the predicted labels and their probabilities, respectively. 
         """
         params = self._load_data(y_pred=y_pred, group_a=group_a, group_b=group_b)
 


### PR DESCRIPTION
This pull request fixes issue #7 by allowing the estimator to be passed directly to the constructor of the ExponentiatedGradientReduction class. The documentation is updated to reflect this. The transform_estimator() method is retained for backwards compatibility. Note two things regarding the constructor: the estimator parameter is optional, and it is the last parameter. If it were the first parameter it would break usages where the parameters were not named. 

Additionally, I added clarification to the EqualizedOdds transform() method as it was not clear what the dictionary actually contained.